### PR TITLE
feat: add release workflow and goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'release'
+on:
+  push:
+    tags:
+      - 'v*'
+permissions:
+  contents: 'write'
+  packages: 'write'
+jobs:
+  release:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - uses: 'actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b' # ratchet:actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: 'actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a' # ratchet:actions/setup-go@v3
+      - uses: 'goreleaser/goreleaser-action@b953231f81b8dfd023c58e0854a721e35037f28b' # ratchet:goreleaser/goreleaser-action@v2
+        with:
+          version: 'latest'
+          args: 'release --clean'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,59 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+before:
+  hooks:
+    - 'go mod tidy'
+    - 'go mod verify'
+
+builds:
+  -
+    id: 'cli'
+    main: './src'
+    env:
+      - 'CGO_ENABLED=0'
+      - 'GO111MODULE=on'
+      - 'GOPROXY=https://proxy.golang.org,direct'
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - '-trimpath'
+    ldflags:
+      - '-s'
+      - '-w'
+      - '-X=github.com/google-github-actions/send-google-chat-webhook/version.Name={{ .ProjectName }}'
+      - '-X=github.com/google-github-actions/send-google-chat-webhook/version.Version={{ .Version }}'
+      - '-X=github.com/google-github-actions/send-google-chat-webhook/version.Commit={{ .Commit }}'
+      - '-extldflags=-static'
+    targets:
+      - 'darwin_amd64'
+      - 'darwin_arm64'
+      - 'linux_amd64'
+      - 'linux_arm64'
+      - 'windows_amd64'
+      - 'windows_arm64'
+    binary: '{{ .ProjectName }}'
+
+archives:
+  - format: 'tar.gz'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    format_overrides:
+      - goos: 'windows'
+        format: 'zip'
+
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA512SUMS'
+  algorithm: 'sha512'
+
+release:
+  draft: false


### PR DESCRIPTION
Create a release workflow that uses goreleaser to release to github. This workflow is triggered by tag starts with `v`. 