### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jobs:
     # ...
 
     - id: 'notify google chat'
-      uses: 'google-github-actions/sent-google-chat-webhook@v0.0.1'
+      uses: 'google-github-actions/send-google-chat-webhook@v0.0.1'
       with:
         webhook_url: '${{ secrets.WEBHOOK_URL }}'
         mention: "<users/all>"
@@ -38,7 +38,7 @@ You can customize the condition for when you want this action is called..
 ```yaml
 - id: 'notify google chat'
   if: ${{ inputs.fail_intentionally }}
-  uses: 'google-github-actions/sent-google-chat-webhook@v0.0.1'
+  uses: 'google-github-actions/send-google-chat-webhook@v0.0.1'
   with:
     webhook_url: '${{ secrets.WEBHOOK_URL }}'
     mention: "<users/all>"


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
Fix typo in README.md . The action name is `send-google-chat-webhook` and not `sent-google-chat-webhook`