### PR TITLE
feature: add support for issue and release trigger

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,14 +13,13 @@
 # limitations under the License.
 
 name: 'send-google-chat-webhhook'
+description: "send message to your google chat workspace"
 inputs:
   webhook_url: 
     description: "chat space webhook url"
-    type: 'string'
     required: true
   mention:
     description: "mention people or not, format <users/user_id>"
-    type: 'string'
     default: '<users/all>'
     required: false
 

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -23,27 +23,27 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestGenerateMessageBody(t *testing.T) {
+func TestGenerateRequestBody(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name            string
-		ghJson          map[string]any
-		jobJson         map[string]any
+		ghJSON          map[string]any
+		jobJSON         map[string]any
 		timestamp       time.Time
 		location        time.Location
 		wantMessageBody map[string]any
 	}{
 		{
 			name: "test_success_workflow",
-			ghJson: map[string]any{
+			ghJSON: map[string]any{
 				"workflow":         "test-workflow",
 				"ref":              "test-ref",
 				"triggering_actor": "test-triggered_actor",
 				"repository":       "test-repository",
 				"run_id":           "test-run-id",
 			},
-			jobJson: map[string]any{
+			jobJSON: map[string]any{
 				"status": "success",
 			},
 			timestamp: time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC),
@@ -64,9 +64,17 @@ func TestGenerateMessageBody(t *testing.T) {
 									{
 										"decoratedText": map[string]any{
 											"startIcon": map[string]any{
+												"iconUrl": widgetRefIconURL,
+											},
+											"text": fmt.Sprintf("<b>Repo: </b> %s", "test-repository"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
 												"iconUrl": "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/quick_reference/default/48px.svg",
 											},
-											"text": fmt.Sprintf("<b>Ref:</b> %s", "test-ref"),
+											"text": fmt.Sprintf("<b>Ref: </b> %s", "test-ref"),
 										},
 									},
 									{
@@ -74,7 +82,7 @@ func TestGenerateMessageBody(t *testing.T) {
 											"startIcon": map[string]any{
 												"knownIcon": "PERSON",
 											},
-											"text": fmt.Sprintf("<b>Run by:</b> %s", "test-triggered_actor"),
+											"text": fmt.Sprintf("<b>Actor: </b> %s", "test-triggered_actor"),
 										},
 									},
 									{
@@ -82,22 +90,14 @@ func TestGenerateMessageBody(t *testing.T) {
 											"startIcon": map[string]any{
 												"knownIcon": "CLOCK",
 											},
-											"text": fmt.Sprintf("<b>Pacific:</b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).In(time.FixedZone("UTC-8", -7*60*60)).Format(time.DateTime)),
-										},
-									},
-									{
-										"decoratedText": map[string]any{
-											"startIcon": map[string]any{
-												"knownIcon": "CLOCK",
-											},
-											"text": fmt.Sprintf("<b>UTC:</b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.DateTime)),
+											"text": fmt.Sprintf("<b>UTC: </b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339)),
 										},
 									},
 									{
 										"buttonList": map[string]any{
 											"buttons": []any{
 												map[string]any{
-													"text": "Open",
+													"text": "Open workflow",
 													"onClick": map[string]any{
 														"openLink": map[string]any{
 															"url": fmt.Sprintf("https://github.com/%s/actions/runs/%s",
@@ -117,15 +117,15 @@ func TestGenerateMessageBody(t *testing.T) {
 		},
 		{
 			name: "test_failed_workflow",
-			ghJson: map[string]any{
+			ghJSON: map[string]any{
 				"workflow":         "test-workflow",
 				"ref":              "test-ref",
 				"triggering_actor": "test-triggered_actor",
 				"repository":       "test-repository",
 				"run_id":           "test-run-id",
 			},
-			jobJson: map[string]any{
-				"status": "xxx",
+			jobJSON: map[string]any{
+				"status": "failure",
 			},
 			timestamp: time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC),
 			wantMessageBody: map[string]any{
@@ -133,7 +133,7 @@ func TestGenerateMessageBody(t *testing.T) {
 					"cardId": "createCardMessage",
 					"card": map[string]any{
 						"header": map[string]any{
-							"title":    fmt.Sprintf("GitHub workflow %s", "xxx"),
+							"title":    fmt.Sprintf("GitHub workflow %s", "failure"),
 							"subtitle": fmt.Sprintf("Workflow: <b>%s</b>", "test-workflow"),
 							"imageUrl": "https://github.githubassets.com/favicons/favicon-failure.png",
 						},
@@ -145,9 +145,17 @@ func TestGenerateMessageBody(t *testing.T) {
 									{
 										"decoratedText": map[string]any{
 											"startIcon": map[string]any{
+												"iconUrl": widgetRefIconURL,
+											},
+											"text": fmt.Sprintf("<b>Repo: </b> %s", "test-repository"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
 												"iconUrl": "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/quick_reference/default/48px.svg",
 											},
-											"text": fmt.Sprintf("<b>Ref:</b> %s", "test-ref"),
+											"text": fmt.Sprintf("<b>Ref: </b> %s", "test-ref"),
 										},
 									},
 									{
@@ -155,7 +163,7 @@ func TestGenerateMessageBody(t *testing.T) {
 											"startIcon": map[string]any{
 												"knownIcon": "PERSON",
 											},
-											"text": fmt.Sprintf("<b>Run by:</b> %s", "test-triggered_actor"),
+											"text": fmt.Sprintf("<b>Actor: </b> %s", "test-triggered_actor"),
 										},
 									},
 									{
@@ -163,26 +171,190 @@ func TestGenerateMessageBody(t *testing.T) {
 											"startIcon": map[string]any{
 												"knownIcon": "CLOCK",
 											},
-											"text": fmt.Sprintf("<b>Pacific:</b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).In(time.FixedZone("UTC-8", -7*60*60)).Format(time.DateTime)),
-										},
-									},
-									{
-										"decoratedText": map[string]any{
-											"startIcon": map[string]any{
-												"knownIcon": "CLOCK",
-											},
-											"text": fmt.Sprintf("<b>UTC:</b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.DateTime)),
+											"text": fmt.Sprintf("<b>UTC: </b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339)),
 										},
 									},
 									{
 										"buttonList": map[string]any{
 											"buttons": []any{
 												map[string]any{
-													"text": "Open",
+													"text": "Open workflow",
 													"onClick": map[string]any{
 														"openLink": map[string]any{
 															"url": fmt.Sprintf("https://github.com/%s/actions/runs/%s",
 																"test-repository", "test-run-id"),
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test_issue_trigger",
+			ghJSON: map[string]any{
+				"workflow":         "test-workflow",
+				"ref":              "test-ref",
+				"triggering_actor": "test-triggered_actor",
+				"repository":       "test-repository",
+				"event_name":       "issues",
+				"event": map[string]any{
+					"action": "opened",
+					"issue": map[string]any{
+						"title":      "test-title",
+						"created_at": time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339),
+						"html_url":   "https://foo.com",
+					},
+				},
+			},
+			jobJSON:   map[string]any{},
+			timestamp: time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC),
+			wantMessageBody: map[string]any{
+				"cardsV2": map[string]any{
+					"cardId": "createCardMessage",
+					"card": map[string]any{
+						"header": map[string]any{
+							"title":    "A issue is opened",
+							"subtitle": fmt.Sprintf("Issue title: <b>%s</b>", "test-title"),
+							"imageUrl": "https://github.githubassets.com/favicons/favicon.png",
+						},
+						"sections": []any{
+							map[string]any{
+								"collapsible":               true,
+								"uncollapsibleWidgetsCount": float64(1),
+								"widgets": []map[string]any{
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"iconUrl": widgetRefIconURL,
+											},
+											"text": fmt.Sprintf("<b>Repo: </b> %s", "test-repository"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"iconUrl": "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/quick_reference/default/48px.svg",
+											},
+											"text": fmt.Sprintf("<b>Ref: </b> %s", "test-ref"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"knownIcon": "PERSON",
+											},
+											"text": fmt.Sprintf("<b>Actor: </b> %s", "test-triggered_actor"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"knownIcon": "CLOCK",
+											},
+											"text": fmt.Sprintf("<b>UTC: </b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339)),
+										},
+									},
+									{
+										"buttonList": map[string]any{
+											"buttons": []any{
+												map[string]any{
+													"text": "Open issue",
+													"onClick": map[string]any{
+														"openLink": map[string]any{
+															"url": "https://foo.com",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "test_release_trigger",
+			ghJSON: map[string]any{
+				"workflow":         "test-workflow",
+				"ref":              "test-ref",
+				"triggering_actor": "test-triggered_actor",
+				"repository":       "test-repository",
+				"event_name":       "release",
+				"event": map[string]any{
+					"action": "released",
+					"release": map[string]any{
+						"name":       "test-title",
+						"created_at": time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339),
+						"html_url":   "https://foo.com",
+					},
+				},
+			},
+			jobJSON:   map[string]any{},
+			timestamp: time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC),
+			wantMessageBody: map[string]any{
+				"cardsV2": map[string]any{
+					"cardId": "createCardMessage",
+					"card": map[string]any{
+						"header": map[string]any{
+							"title":    "A release is released",
+							"subtitle": fmt.Sprintf("Release name: <b>%s</b>", "test-title"),
+							"imageUrl": "https://github.githubassets.com/favicons/favicon.png",
+						},
+						"sections": []any{
+							map[string]any{
+								"collapsible":               true,
+								"uncollapsibleWidgetsCount": float64(1),
+								"widgets": []map[string]any{
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"iconUrl": widgetRefIconURL,
+											},
+											"text": fmt.Sprintf("<b>Repo: </b> %s", "test-repository"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"iconUrl": "https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/quick_reference/default/48px.svg",
+											},
+											"text": fmt.Sprintf("<b>Ref: </b> %s", "test-ref"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"knownIcon": "PERSON",
+											},
+											"text": fmt.Sprintf("<b>Actor: </b> %s", "test-triggered_actor"),
+										},
+									},
+									{
+										"decoratedText": map[string]any{
+											"startIcon": map[string]any{
+												"knownIcon": "CLOCK",
+											},
+											"text": fmt.Sprintf("<b>UTC: </b> %s", time.Date(2023, time.April, 25, 17, 44, 57, 0, time.UTC).UTC().Format(time.RFC3339)),
+										},
+									},
+									{
+										"buttonList": map[string]any{
+											"buttons": []any{
+												map[string]any{
+													"text": "Open release",
+													"onClick": map[string]any{
+														"openLink": map[string]any{
+															"url": "https://foo.com",
 														},
 													},
 												},
@@ -202,7 +374,8 @@ func TestGenerateMessageBody(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			gotMessageBody, err := generateMessageBody(tc.ghJson, tc.jobJson, tc.timestamp)
+			t.Parallel()
+			gotMessageBody, err := generateRequestBody(generateMessageBodyContent(tc.ghJSON, tc.jobJSON, tc.timestamp))
 			if err != nil {
 				t.Fatalf("failed to generate messag body %v", err)
 			}


### PR DESCRIPTION
Add support for when event is triggered by issues open and release released. The example notification card is like below:

![image](https://github.com/google-github-actions/send-google-chat-webhook/assets/55097418/25cc7956-2c8c-4727-8728-37b2bd3723cf)
![image](https://github.com/google-github-actions/send-google-chat-webhook/assets/55097418/78dd6da5-dd30-4449-a5ea-da80f6dd3a60)
