### PR TITLE
Update tag to 0.0.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         BINARY_NAME: "send-google-chat-webhook"
         # manully update VERSION after each release
         # VERSION should not contain v.
-        VERSION: "0.0.2"
+        VERSION: "0.0.4"
       run: |-
         case "${RUNNER_OS}" in
           "Linux")


### PR DESCRIPTION
This PR won't be merged until new release of `0.0.4` is created

Update: Release v0.0.4 is now done: https://github.com/google-github-actions/send-google-chat-webhook/actions/runs/11600922899